### PR TITLE
typo + formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 [![npm](https://img.shields.io/npm/v/object-to-class.svg)](https://www.npmjs.com/package/object-to-class) [![Build Status](https://travis-ci.org/isysd/object-to-class.svg?branch=master)](https://travis-ci.org/isysd/object-to-class) [![Coverage Status](https://coveralls.io/repos/github/isysd/object-to-class/badge.svg?branch=master)](https://coveralls.io/github/isysd/object-to-class?branch=master)
 
-Generate a dynamically named es6 class from any JS object.
+Generate a dynamically named ES6 class from any JavaScript object.
 
 ### install
 
-`npm i object-to-class`
+`npm install object-to-class`
 
 ### Usage
 
 Simply pass the object you wish to convert to a class, and an optional name.
 
-```
+```javascript
 const o2c = require('object-to-class')
 const myObj = {
   'prop': 'my property'
@@ -27,14 +27,12 @@ myinst.prop // my property
 myinst.fn() // my function
 ```
 
-The result can be used like any other es6 class, with normal inheritence.
+The result can be used like any other ES6 class, with normal inheritance.
 
-```
+```javascript
 class MySubclass extends MyClass {}
 let myinst = new MySubclass()
 mysubinst instanceof MyClass // true
 mysubinst.prop // my property
 mysubinst.fn() // my function
-
 ```
-


### PR DESCRIPTION
I really just wanted to fix a typo, and then I did a bit more cleanup while I was at it. Code snippet changes are due to adding `javascript` as the snippet type to activate syntax highlighting.